### PR TITLE
Fix escape character deprecation warnings

### DIFF
--- a/src/circle_fitting_3d/circle_3d.py
+++ b/src/circle_fitting_3d/circle_3d.py
@@ -144,7 +144,7 @@ class Circle3D:
         Parameters
         ----------
         t : Union[np.ndarray, Sequence]
-            .. math:: 0 \le t \le 2\pi
+            .. math:: 0 \\le t \\le 2\\pi
 
         Returns
         -------


### PR DESCRIPTION
There are deprecation warnings when using circle-fitting-3d due to \ being an escape character.:

`circle_fitting_3d/circle_3d.py:141: DeprecationWarning: invalid escape sequence '\l'`

This PR fixes the warnings.

Love your package!